### PR TITLE
Change default port to 7500

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Running the app is done with:
 npm start
 ```
 
-which executes `node ./bin/www` to start the server (port 3000 by default).
+which executes `node ./bin/www` to start the server (port 7500 by default).
 
 ## Structure
 

--- a/bin/www
+++ b/bin/www
@@ -12,7 +12,7 @@ var http = require('http');
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || '3000');
+var port = normalizePort(process.env.PORT || '7500');
 app.set('port', port);
 
 /**


### PR DESCRIPTION
## Summary
- update default server port from 3000 to 7500
- document new default port in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684085562660833399b60a6a24121ceb